### PR TITLE
Android should return BCP47 tag, not localized string

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -435,8 +435,8 @@ Get the string identifier for the client's current language.
 
 ### Description
 
-Returns the language identifier string to the `successCallback` with a
-`properties` object as a parameter. That object should have a `value`
+Returns the BCP-47 compliant language identifier tag to the `successCallback` 
+with a `properties` object as a parameter. That object should have a `value`
 property with a `String` value.
 
 If there is an error getting the language, then the `errorCallback`
@@ -453,13 +453,17 @@ error's expected code is `GlobalizationError.UNKNOWN\_ERROR`.
 ### Example
 
 When the browser is set to the `en\_US` locale, this should display a
-popup dialog with the text `language: English`:
+popup dialog with the text `language: en_US`:
 
     navigator.globalization.getPreferredLanguage(
         function (language) {alert('language: ' + language.value + '\n');},
         function () {alert('Error getting language\n');}
     );
 
+### Android Quirks
+
+- Returns the ISO 639-1 two-letter language code, upper case ISO 3166-1 
+country code and variant separated by underscores. Examples: "en", "en_US", "_US"
 
 ### Windows Phone 8 Quirks
 

--- a/src/android/Globalization.java
+++ b/src/android/Globalization.java
@@ -159,7 +159,7 @@ public class Globalization extends CordovaPlugin  {
     private JSONObject getPreferredLanguage() throws GlobalizationError {
         JSONObject obj = new JSONObject();
         try {
-            obj.put("value", Locale.getDefault().getDisplayLanguage().toString());
+            obj.put("value", Locale.getDefault().toString());
             return obj;
         } catch (Exception e) {
             throw new GlobalizationError(GlobalizationError.UNKNOWN_ERROR);


### PR DESCRIPTION
For https://issues.apache.org/jira/browse/CB-4602
I still want to test the consistency with iOS.
Return the Locale.getDefault().toString() which according to the Android docs [1], contains a two-letter lowercase ISO language code (ISO 639-1) followed by an underscore, followed by the two-letter uppercase country code (ISO 3166-1). As best I can tell, these two specs (and some more) are what make up BCP 47, therefore we should be able to assume that this will always return BCP 47 compliant language tags. 

I did notice that sometimes toString() will leave out country or language codes if they don't exist. For example, if you set locale to be Locale.CHINESE, then you'll get back "zh" - no country code. I'm not sure if this is BCP 47, or if there is anything we can do about it.

Finally, since this changes an API, would we have to do a major bump to the plugin version number? I thought about deprecating the old code and/or creating a new API method but chose against that since this is a bug fix and not a feature request. I think the version number should be bumped though...

[1]  http://developer.android.com/reference/java/util/Locale.html
