### PR TITLE
CB-9476: Mobilespec crash on startup when running on Windows 10.

### DIFF
--- a/src/windows/GlobalizationProxy.js
+++ b/src/windows/GlobalizationProxy.js
@@ -13,7 +13,7 @@
 */
 
 var GlobalizationError = require('./GlobalizationError');
-var locale = navigator.userLanguage;
+var locale = navigator.userLanguage || navigator.language;
 
 var decimalFormatter;
 var currencyFormatter;


### PR DESCRIPTION
Windows 10 apparently deprecated and removed the navigator.userLanguage
property.  This change addresses the switch to navigator.language.