### PR TITLE
CB-10792 -Cannot install cordova-plugin-globalization with cordova-windows on Ubuntu

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -120,7 +120,7 @@
         <js-module src="src/windows/GlobalizationProxy.js" name="GlobalizationProxy">
             <runs/>
         </js-module>
-        <framework src="src/Windows/GlobalizationProxy.winmd" custom="true"/>
+        <framework src="src/windows/GlobalizationProxy.winmd" custom="true"/>
     </platform>
 
     <!-- windows -->
@@ -128,7 +128,7 @@
         <js-module src="src/windows/GlobalizationProxy.js" name="GlobalizationProxy">
             <runs/>
         </js-module>
-        <framework src="src/Windows/GlobalizationProxy.winmd" custom="true"/>
+        <framework src="src/windows/GlobalizationProxy.winmd" custom="true"/>
     </platform>
 
     <!-- tizen -->


### PR DESCRIPTION
- Make Windows lower-case in plugin.xml